### PR TITLE
Alow setting data dirs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,28 @@
 .MAIN:          all
 PROG=	larn
 MAN=	larn.6
-CPPFLAGS+=-DBSD -DVER=12 -DSUBVER=0 -DNONAP -DUIDSCORE -DTERMIOS
+
+# Set the data and score dir locations here
+FILESDIR=./datfiles
+SCORESDIR=./scores
+
+PATH_LOG=${SCORESDIR}/llog12.0
+PATH_SCORE=${SCORESDIR}/lscore12.0
+PATH_HELP=${FILESDIR}/larn.help
+PATH_LEVELS=${FILESDIR}/larnmaze
+PATH_PLAYERIDS={SCORESDIR}/playerids
+
+CPPFLAGS+=-DBSD \
+          -DVER=12 \
+          -DSUBVER=0 \
+          -DNONAP \
+          -DUIDSCORE \
+          -DTERMIOS \
+          -D_PATH_LOG=\"${PATH_LOG}\" \
+          -D_PATH_SCORE=\"${PATH_SCORE}\" \
+          -D_PATH_HELP=\"${PATH_HELP}\" \
+          -D_PATH_LEVELS=\"${PATH_LEVELS}\" \
+          -D_PATH_PLAYERIDS=\"${PATH_PLAYERIDS}\"
 SRCS=	main.c object.c create.c tok.c display.c global.c data.c io.c \
 	monster.c store.c diag.c help.c config.c nap.c bill.c scores.c \
 	signal.c action.c moreobj.c movem.c regen.c fortune.c savelev.c
@@ -69,13 +90,6 @@ DPADD=	${LIBTERMINFO}
 LDADD= -lcurses
 HIDEGAME=hidegame
 SETGIDGAME=yes
-
-#.if ${MKSHARE} != "no"
-DAT=larnmaze larnopts larn.help
-FILES=${DAT:S@^@${.CURDIR}/datfiles/@g}
-#FILESDIR=/usr/share/games/larn
-FILESDIR=./share/larn
-#.endif
 
 COPTS.display.c += -Wno-format-nonliteral
 COPTS.monster.c += -Wno-format-nonliteral

--- a/pathnames.h
+++ b/pathnames.h
@@ -31,8 +31,18 @@
  *	@(#)pathnames.h	5.2 (Berkeley) 4/27/95
  */
 
-#define	_PATH_LOG		"/var/games/larn/llog12.0"
-#define	_PATH_SCORE		"/var/games/larn/lscore12.0"
-#define	_PATH_HELP		"/usr/share/games/larn/larn.help"
-#define	_PATH_LEVELS		"/usr/share/games/larn/larnmaze"
-#define	_PATH_PLAYERIDS		"/var/games/larn/playerids"
+#ifndef _PATH_LOG
+  #define	_PATH_LOG		"/var/games/larn/llog12.0"
+#endif
+#ifndef _PATH_SCORE
+  #define	_PATH_SCORE		"/var/games/larn/lscore12.0"
+#endif
+#ifndef _PATH_HELP
+  #define	_PATH_HELP		"/usr/share/games/larn/larn.help"
+#endif
+#ifndef _PATH_LEVELS
+  #define	_PATH_LEVELS		"/usr/share/games/larn/larnmaze"
+#endif
+#ifndef _PATH_PLAYERIDS
+  #define	_PATH_PLAYERIDS		"/var/games/larn/playerids"
+#endif


### PR DESCRIPTION
Customize where larn scores it's data. Note that a `make install` will not work with the existing structure. FILESDIR and SCORESDIR must be set to the desired location, and the larn binary copied somewhere in PATH. Make sure FILESDIR and SCORESDIR actually exist.